### PR TITLE
Enable library usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,20 +47,19 @@ Use `mcp__monoread__read_url_content` tool instead of builtin Fetch tool to read
 ### Library Usage
 
 ```typescript
-import { extractContent } from "monoread";
+import { monoread } from 'monoread';
 
 // Basic usage
-const result = await extractContent("https://example.com/article");
-if (result.isOk()) {
-  console.log(result.value.content);
-  console.log(result.value.title);
-  console.log(result.value.url);
+const result = await monoread('https://example.com/article');
+if (result.success) {
+  console.log(result.content);
+  console.log(result.title);
+  console.log(result.url);
 }
 
-// With Notion API key
-const notionResult = await extractContent("https://notion.so/your-page-id", {
-  notionApiKey: "your-integration-token",
-});
+// For Notion pages, set NOTION_API_KEY environment variable
+process.env.NOTION_API_KEY = 'your-integration-token';
+const notionResult = await monoread('https://notion.so/your-page-id');
 ```
 
 ## Providers

--- a/README.md
+++ b/README.md
@@ -23,6 +23,26 @@ npx monoread read https://github.com/yukukotani/monoread/blob/main/README.md
 npx monoread read https://notion.so/your-page-id
 ```
 
+### Library Usage
+
+```typescript
+import { extractContent } from 'monoread';
+
+// Basic usage
+const result = await extractContent('https://example.com/article');
+if (result.isOk()) {
+  console.log(result.value.content);
+  console.log(result.value.title);
+  console.log(result.value.url);
+}
+
+// With Notion API key
+const notionResult = await extractContent(
+  'https://notion.so/your-page-id',
+  { notionApiKey: 'your-integration-token' }
+);
+```
+
 ### MCP Usage
 
 Add to Claude Code:

--- a/README.md
+++ b/README.md
@@ -23,26 +23,6 @@ npx monoread read https://github.com/yukukotani/monoread/blob/main/README.md
 npx monoread read https://notion.so/your-page-id
 ```
 
-### Library Usage
-
-```typescript
-import { extractContent } from 'monoread';
-
-// Basic usage
-const result = await extractContent('https://example.com/article');
-if (result.isOk()) {
-  console.log(result.value.content);
-  console.log(result.value.title);
-  console.log(result.value.url);
-}
-
-// With Notion API key
-const notionResult = await extractContent(
-  'https://notion.so/your-page-id',
-  { notionApiKey: 'your-integration-token' }
-);
-```
-
 ### MCP Usage
 
 Add to Claude Code:
@@ -62,6 +42,25 @@ Then add something like this to your CLAUDE.md:
 
 ```
 Use `mcp__monoread__read_url_content` tool instead of builtin Fetch tool to read web pages.
+```
+
+### Library Usage
+
+```typescript
+import { extractContent } from "monoread";
+
+// Basic usage
+const result = await extractContent("https://example.com/article");
+if (result.isOk()) {
+  console.log(result.value.content);
+  console.log(result.value.title);
+  console.log(result.value.url);
+}
+
+// With Notion API key
+const notionResult = await extractContent("https://notion.so/your-page-id", {
+  notionApiKey: "your-integration-token",
+});
 ```
 
 ## Providers

--- a/README_ja.md
+++ b/README_ja.md
@@ -41,6 +41,24 @@ monoread read https://example.com/article
 monoread read https://github.com/owner/repo/blob/main/README.md
 ```
 
+### ライブラリとしての使用
+
+```typescript
+import { monoread } from 'monoread';
+
+// 基本的な使用方法
+const result = await monoread('https://example.com/article');
+if (result.success) {
+  console.log(result.content);
+  console.log(result.title);
+  console.log(result.url);
+}
+
+// Notionページの場合、NOTION_API_KEY環境変数を設定
+process.env.NOTION_API_KEY = 'your-integration-token';
+const notionResult = await monoread('https://notion.so/your-page-id');
+```
+
 ### MCP サーバーモード
 
 Claude Code に追加:

--- a/package.json
+++ b/package.json
@@ -4,16 +4,22 @@
   "type": "module",
   "description": "CLI tool for reading any URL in AI-optimized format",
   "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "bin": {
-    "monoread": "./dist/index.js"
+    "monoread": "./dist/cli.js"
   },
+  "files": [
+    "dist",
+    "package.json"
+  ],
   "scripts": {
     "build": "tsdown",
-    "dev": "tsx src/index.ts",
-    "start": "node ./dist/index.js",
-    "mcp": "tsx src/index.ts mcp",
-    "mcp:debug": "LOG_LEVEL=debug tsx src/index.ts mcp",
-    "mcp:inspector": "npx @modelcontextprotocol/inspector@latest tsx src/index.ts mcp",
+    "dev": "tsx src/cli.ts",
+    "start": "node ./dist/cli.js",
+    "mcp": "tsx src/cli.ts mcp",
+    "mcp:debug": "LOG_LEVEL=debug tsx src/cli.ts mcp",
+    "mcp:inspector": "npx @modelcontextprotocol/inspector@latest tsx src/cli.ts mcp",
     "test": "vitest run",
     "test:watch": "vitest --watch",
     "test:coverage": "vitest --coverage",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+import { execute } from "./presentation/cli/cli.js";
+
+const main = async (): Promise<void> => {
+  await execute();
+};
+
+main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { extractContent } from "./usecase/extract-content.js";
+export { readUrl } from "./usecase/read-url.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { readUrl } from "./usecase/read-url.js";
+export { readUrl as monoread } from "./usecase/read-url.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,1 @@
-#!/usr/bin/env node
-
-import { execute } from "./presentation/cli/cli.js";
-
-const main = async (): Promise<void> => {
-  await execute();
-};
-
-main();
+export { extractContent } from "./usecase/extract-content.js";

--- a/src/libs/logger.ts
+++ b/src/libs/logger.ts
@@ -10,7 +10,7 @@ export type LogLevel =
   | "fatal";
 
 function getLogLevelFromEnv(): LogLevel {
-  const envLevel = process.env.LOG_LEVEL?.toLowerCase();
+  const envLevel = process.env.MONOREAD_LOG_LEVEL?.toLowerCase();
   const validLevels: LogLevel[] = [
     "silent",
     "trace",
@@ -31,18 +31,18 @@ function getLogLevelFromEnv(): LogLevel {
 function createRootLogger(): pino.Logger {
   const logLevel = getLogLevelFromEnv();
 
-  const options: pino.LoggerOptions = {
+  return pino({
     level: logLevel,
-  };
-
-  options.transport = {
-    target: "pino-pretty",
-    options: {
-      colorize: true,
+    transport: {
+      target: "pino-pretty",
+      options: {
+        colorize: false,
+        ignore: "pid,hostname",
+        destination:
+          process.env.MONOREAD_LOG_FILE || "~/.cache/monoread/monoread.log",
+      },
     },
-  };
-
-  return pino(options);
+  });
 }
 
 const rootLogger: pino.Logger = createRootLogger();

--- a/src/libs/logger.ts
+++ b/src/libs/logger.ts
@@ -9,30 +9,9 @@ export type LogLevel =
   | "error"
   | "fatal";
 
-function getLogLevelFromEnv(): LogLevel {
-  const envLevel = process.env.MONOREAD_LOG_LEVEL?.toLowerCase();
-  const validLevels: LogLevel[] = [
-    "silent",
-    "trace",
-    "debug",
-    "info",
-    "warn",
-    "error",
-    "fatal",
-  ];
-
-  if (envLevel && validLevels.includes(envLevel as LogLevel)) {
-    return envLevel as LogLevel;
-  }
-
-  return "silent";
-}
-
 function createRootLogger(): pino.Logger {
-  const logLevel = getLogLevelFromEnv();
-
   return pino({
-    level: logLevel,
+    level: process.env.MONOREAD_LOG_LEVEL || "silent",
     transport: {
       target: "pino-pretty",
       options: {
@@ -40,6 +19,7 @@ function createRootLogger(): pino.Logger {
         ignore: "pid,hostname",
         destination:
           process.env.MONOREAD_LOG_FILE || "~/.cache/monoread/monoread.log",
+        mkdir: true,
       },
     },
   });

--- a/src/presentation/cli/global-args.ts
+++ b/src/presentation/cli/global-args.ts
@@ -5,6 +5,5 @@ export const globalArgs = {
     type: "enum",
     description: "Log level",
     choices: ["silent", "trace", "debug", "info", "warn", "error", "fatal"],
-    default: "silent",
   },
 } as const satisfies Args;

--- a/src/presentation/cli/read-command.ts
+++ b/src/presentation/cli/read-command.ts
@@ -1,6 +1,6 @@
 import { define } from "gunshi";
 import { createLogger } from "../../libs/logger.js";
-import { extractContent } from "../../usecase/extract-content.js";
+import { readUrl } from "../../usecase/read-url.js";
 import { globalArgs } from "./global-args.js";
 
 export const readCommand = define({
@@ -30,7 +30,7 @@ export const readCommand = define({
       throw new Error("Invalid URL format");
     }
 
-    const result = await extractContent(url);
+    const result = await readUrl(url);
 
     if (result.success) {
       logger.info({ url }, "Content extracted successfully");

--- a/src/presentation/mcp/read-url-content.test.ts
+++ b/src/presentation/mcp/read-url-content.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ContentResult } from "../../libs/types.js";
-import { extractContent } from "../../usecase/extract-content.js";
+import { readUrl } from "../../usecase/read-url.js";
 
-vi.mock("../../usecase/extract-content.js");
+vi.mock("../../usecase/read-url.js");
 
 describe("read_url_contentツール", () => {
-  const mockedExtractContent = vi.mocked(extractContent);
+  const mockedReadUrl = vi.mocked(readUrl);
 
   describe("正常系", () => {
     it("有効なURLでコンテンツを抽出できる", async () => {
@@ -15,11 +15,11 @@ describe("read_url_contentツール", () => {
         content: mockContent,
       };
 
-      mockedExtractContent.mockResolvedValue(mockResult);
+      mockedReadUrl.mockResolvedValue(mockResult);
 
-      const result = await mockedExtractContent("https://example.com");
+      const result = await mockedReadUrl("https://example.com");
 
-      expect(mockedExtractContent).toHaveBeenCalledWith("https://example.com");
+      expect(mockedReadUrl).toHaveBeenCalledWith("https://example.com");
       expect(result).toEqual(mockResult);
     });
 
@@ -30,11 +30,11 @@ describe("read_url_contentツール", () => {
         content: mockContent,
       };
 
-      mockedExtractContent.mockResolvedValue(mockResult);
+      mockedReadUrl.mockResolvedValue(mockResult);
 
-      const result = await mockedExtractContent("https://github.com/user/repo");
+      const result = await mockedReadUrl("https://github.com/user/repo");
 
-      expect(mockedExtractContent).toHaveBeenCalledWith(
+      expect(mockedReadUrl).toHaveBeenCalledWith(
         "https://github.com/user/repo",
       );
       expect(result).toEqual(mockResult);
@@ -48,11 +48,11 @@ describe("read_url_contentツール", () => {
         error: "Invalid URL format",
       };
 
-      mockedExtractContent.mockResolvedValue(mockResult);
+      mockedReadUrl.mockResolvedValue(mockResult);
 
-      const result = await mockedExtractContent("not-a-valid-url");
+      const result = await mockedReadUrl("not-a-valid-url");
 
-      expect(mockedExtractContent).toHaveBeenCalledWith("not-a-valid-url");
+      expect(mockedReadUrl).toHaveBeenCalledWith("not-a-valid-url");
       expect(result).toEqual(mockResult);
     });
 
@@ -62,13 +62,11 @@ describe("read_url_contentツール", () => {
         error: "Failed to fetch URL: 404 Not Found",
       };
 
-      mockedExtractContent.mockResolvedValue(mockResult);
+      mockedReadUrl.mockResolvedValue(mockResult);
 
-      const result = await mockedExtractContent(
-        "https://example.com/not-found",
-      );
+      const result = await mockedReadUrl("https://example.com/not-found");
 
-      expect(mockedExtractContent).toHaveBeenCalledWith(
+      expect(mockedReadUrl).toHaveBeenCalledWith(
         "https://example.com/not-found",
       );
       expect(result).toEqual(mockResult);
@@ -80,11 +78,11 @@ describe("read_url_contentツール", () => {
         error: "Failed to extract content: Network error",
       };
 
-      mockedExtractContent.mockResolvedValue(mockResult);
+      mockedReadUrl.mockResolvedValue(mockResult);
 
-      const result = await mockedExtractContent("https://example.com");
+      const result = await mockedReadUrl("https://example.com");
 
-      expect(mockedExtractContent).toHaveBeenCalledWith("https://example.com");
+      expect(mockedReadUrl).toHaveBeenCalledWith("https://example.com");
       expect(result).toEqual(mockResult);
     });
 
@@ -94,20 +92,18 @@ describe("read_url_contentツール", () => {
         error: "No content could be extracted from the page",
       };
 
-      mockedExtractContent.mockResolvedValue(mockResult);
+      mockedReadUrl.mockResolvedValue(mockResult);
 
-      const result = await mockedExtractContent("https://example.com/empty");
+      const result = await mockedReadUrl("https://example.com/empty");
 
-      expect(mockedExtractContent).toHaveBeenCalledWith(
-        "https://example.com/empty",
-      );
+      expect(mockedReadUrl).toHaveBeenCalledWith("https://example.com/empty");
       expect(result).toEqual(mockResult);
     });
 
     it("予期しないエラーを処理する", async () => {
-      mockedExtractContent.mockRejectedValue(new Error("Unexpected error"));
+      mockedReadUrl.mockRejectedValue(new Error("Unexpected error"));
 
-      await expect(mockedExtractContent("https://example.com")).rejects.toThrow(
+      await expect(mockedReadUrl("https://example.com")).rejects.toThrow(
         "Unexpected error",
       );
     });

--- a/src/presentation/mcp/server.ts
+++ b/src/presentation/mcp/server.ts
@@ -5,7 +5,7 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { extractContent } from "../../usecase/extract-content.js";
+import { readUrl } from "../../usecase/read-url.js";
 
 const ReadUrlSchema = z.object({
   url: z.string().url().describe("The URL to read content from"),
@@ -71,7 +71,7 @@ export async function startMcpServer(): Promise<void> {
       });
 
       try {
-        const result = await extractContent(url);
+        const result = await readUrl(url);
 
         if (result.success) {
           await server.sendLoggingMessage({

--- a/src/usecase/read-url.test.ts
+++ b/src/usecase/read-url.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert";
 import { beforeEach, describe, it, vi } from "vitest";
 import type { ContentProvider, ContentResult } from "../libs/types.js";
-import { extractContent } from "./extract-content.js";
+import { readUrl } from "./read-url.js";
 
-// テスト用のextractContent関数（プロバイダの配列を受け取る）
-async function extractContentWithProviders(
+// テスト用のreadUrl関数（プロバイダの配列を受け取る）
+async function readUrlWithProviders(
   url: string,
   providers: ContentProvider[],
 ): Promise<ContentResult> {
@@ -53,9 +53,9 @@ const mockNoMatchProvider: ContentProvider = {
   }),
 };
 
-describe("extractContent", () => {
+describe("readUrl", () => {
   it("マッチするプロバイダが成功した場合、その結果を返す", async () => {
-    const result = await extractContentWithProviders("test-url", [
+    const result = await readUrlWithProviders("test-url", [
       mockSuccessProvider,
     ]);
 
@@ -64,7 +64,7 @@ describe("extractContent", () => {
   });
 
   it("最初のプロバイダが失敗した場合、次のプロバイダを試す", async () => {
-    const result = await extractContentWithProviders("test-url", [
+    const result = await readUrlWithProviders("test-url", [
       mockFailProvider,
       mockSuccessProvider,
     ]);
@@ -74,7 +74,7 @@ describe("extractContent", () => {
   });
 
   it("URLにマッチしないプロバイダは呼び出されない", async () => {
-    const result = await extractContentWithProviders("test-url", [
+    const result = await readUrlWithProviders("test-url", [
       mockNoMatchProvider,
       mockSuccessProvider,
     ]);
@@ -85,7 +85,7 @@ describe("extractContent", () => {
 
   it("全てのプロバイダが失敗した場合、フォールバック処理が実行される", async () => {
     // 無効なURLでフォールバック処理をテスト
-    const result = await extractContentWithProviders("invalid-url", [
+    const result = await readUrlWithProviders("invalid-url", [
       mockFailProvider,
     ]);
 
@@ -128,7 +128,7 @@ describe("Content extraction fallback integration", () => {
     );
     mockIsReadabilityResultEmpty.mockReturnValue(false);
 
-    const result = await extractContent("https://example.com/page");
+    const result = await readUrl("https://example.com/page");
 
     assert(result.success);
     assert(
@@ -163,7 +163,7 @@ describe("Content extraction fallback integration", () => {
       content: "# LLMS.txt Content\\n\\nThis is from llms.txt fallback.",
     });
 
-    const result = await extractContent("https://example.com/page");
+    const result = await readUrl("https://example.com/page");
 
     assert(result.success);
     if (result.success) {
@@ -200,7 +200,7 @@ describe("Content extraction fallback integration", () => {
         "# LLMS.txt Fallback\\n\\nThis content was retrieved after readability failed.",
     });
 
-    const result = await extractContent("https://example.com/page");
+    const result = await readUrl("https://example.com/page");
 
     assert(result.success);
     if (result.success) {
@@ -228,7 +228,7 @@ describe("Content extraction fallback integration", () => {
         "# LLMS.txt Success\\n\\nContent from llms.txt when page is not found.",
     });
 
-    const result = await extractContent("https://example.com/missing-page");
+    const result = await readUrl("https://example.com/missing-page");
 
     assert(result.success);
     if (result.success) {
@@ -265,7 +265,7 @@ describe("Content extraction fallback integration", () => {
       error: "llms.txt not found",
     });
 
-    const result = await extractContent("https://example.com/page");
+    const result = await readUrl("https://example.com/page");
 
     assert(!result.success);
     assert(result.error === "Failed to extract content");

--- a/src/usecase/read-url.ts
+++ b/src/usecase/read-url.ts
@@ -15,7 +15,7 @@ const PROVIDERS: ContentProvider[] = [
   createHttpProvider(),
 ];
 
-export async function extractContent(url: string): Promise<ContentResult> {
+export async function readUrl(url: string): Promise<ContentResult> {
   const logger = createLogger("content-extractor");
 
   logger.info(


### PR DESCRIPTION
## Summary
Made changes to enable monoread to be used as a library.

## Changes
- Export `extractContent` function for external usage
- Fix logger log level issues
- Rename functions for better clarity