### PR TITLE
update @modelcontextprotocol/sdk to v1.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@mizchi/readability": "^0.7.7",
-    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@modelcontextprotocol/sdk": "^1.18.0",
     "@praha/byethrow": "^0.7.0",
     "fetch-notion-page": "^0.0.1",
     "gunshi": "0.27.0-alpha.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.7.7
         version: 0.7.7
       '@modelcontextprotocol/sdk':
-        specifier: ^1.0.0
-        version: 1.17.2
+        specifier: ^1.18.0
+        version: 1.18.0
       '@praha/byethrow':
         specifier: ^0.7.0
         version: 0.7.0
@@ -358,8 +358,8 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
-  '@modelcontextprotocol/sdk@1.17.2':
-    resolution: {integrity: sha512-EFLRNXR/ixpXQWu6/3Cu30ndDFIFNaqUXcTqsGebujeMan9FzhAaFFswLRiFj61rgygDRr8WO1N+UijjgRxX9g==}
+  '@modelcontextprotocol/sdk@1.18.0':
+    resolution: {integrity: sha512-JvKyB6YwS3quM+88JPR0axeRgvdDu3Pv6mdZUy+w4qVkCzGgumb9bXG/TmtDRQv+671yaofVfXSQmFLlWU5qPQ==}
     engines: {node: '>=18'}
 
   '@napi-rs/wasm-runtime@1.0.3':
@@ -1921,13 +1921,13 @@ snapshots:
 
   '@mizchi/readability@0.7.7':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.17.2
+      '@modelcontextprotocol/sdk': 1.18.0
       htmlparser2: 10.0.0
       zod: 3.25.76
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.17.2':
+  '@modelcontextprotocol/sdk@1.18.0':
     dependencies:
       ajv: 6.12.6
       content-type: 1.0.5
@@ -1977,7 +1977,7 @@ snapshots:
 
   '@praha/byethrow-mcp@0.1.3':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.17.2
+      '@modelcontextprotocol/sdk': 1.18.0
       citty: 0.1.6
       consola: 3.4.2
       zod: 3.25.76


### PR DESCRIPTION
to include https://github.com/modelcontextprotocol/typescript-sdk/pull/882